### PR TITLE
Fix compilation with futures 0.3-alpha.18

### DIFF
--- a/src/timer/ext.rs
+++ b/src/timer/ext.rs
@@ -167,18 +167,17 @@ where
     unsafe_pinned!(stream: S);
 }
 
-impl<S> TryStream for TimeoutStream<S>
+impl<S> Stream for TimeoutStream<S>
 where
     S: TryStream,
     S::Error: From<io::Error>,
 {
-    type Ok = S::Ok;
-    type Error = S::Error;
+    type Item = Result<S::Ok, S::Error>;
 
-    fn try_poll_next(
+    fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Ok, Self::Error>>> {
+    ) -> Poll<Option<Self::Item>> {
         let dur = self.dur;
 
         let r = self.as_mut().stream().try_poll_next(cx);

--- a/src/timer/global/wasm.rs
+++ b/src/timer/global/wasm.rs
@@ -1,4 +1,4 @@
-use futures::task::ArcWake;
+use futures::task::{ArcWake, self};
 use parking_lot::Mutex;
 use std::convert::TryFrom;
 use std::future::Future;
@@ -33,7 +33,7 @@ fn schedule_callback(timer: Arc<Mutex<Timer>>, when: Duration) {
             // We start by polling the timer. If any new `Delay` is created, the waker will be used
             // to wake up this task pre-emptively. As such, we pass a `Waker` that calls
             // `schedule_callback` with a delay of `0`.
-            let waker = Arc::new(Waker { timer: timer.clone() }).into_waker();
+            let waker = task::waker(Arc::new(Waker { timer: timer.clone() }));
             let _ = Future::poll(Pin::new(&mut *timer_lock), &mut Context::from_waker(&waker));
 
             // Notify the timers that are ready.


### PR DESCRIPTION
TryFuture and TryStream are now sealed, types should only implement Stream or
Future directly.

Also, `ArcWake::into_waker` is now just the free function `task::waker`.