### PR TITLE
Remove pin-utils and bump crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,14 @@ repository = "https://github.com/tomaka/wasm-timer"
 
 [dependencies]
 futures = "0.3.1"
-parking_lot = "0.9"
-pin-utils = "0.1.0-alpha.4"
+parking_lot = "0.10"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-js-sys = "0.3.31"
-send_wrapper = "0.2"
-wasm-bindgen = "0.2.37"
-wasm-bindgen-futures = "0.4.4"
-web-sys = { version = "0.3.31", features = ["Performance", "Window"] }
+js-sys = "0.3.32"
+send_wrapper = "0.4"
+wasm-bindgen = "0.2.55"
+wasm-bindgen-futures = "0.4.5"
+web-sys = { version = "0.3.32", features = ["Performance", "Window"] }
 
 [dev-dependencies]
 async-std = "1.0"

--- a/src/timer/global/desktop.rs
+++ b/src/timer/global/desktop.rs
@@ -7,8 +7,7 @@ use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 use std::thread;
 use std::thread::Thread;
 use std::time::Instant;
-
-use pin_utils::pin_mut;
+use std::pin::Pin;
 
 use crate::{Timer, TimerHandle};
 
@@ -54,11 +53,11 @@ impl Drop for HelperThread {
     }
 }
 
-fn run(timer: Timer, done: Arc<AtomicBool>) {
+fn run(mut timer: Timer, done: Arc<AtomicBool>) {
     let mut waker = current_thread_waker();
     let mut cx = Context::from_waker(&mut waker);
 
-    pin_mut!(timer);
+    let mut timer = Pin::new(&mut timer);
     while !done.load(Ordering::SeqCst) {
         drop(timer.as_mut().poll(&mut cx));
 


### PR DESCRIPTION
`pin-utils` isn't really needed because we can just use `Pin::into_inner`.