### PR TITLE
Fix an issue with parking_lot >= 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ parking_lot = "0.11"
 pin-utils = "0.1.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+parking_lot = { version = "0.11", features = ["wasm-bindgen"] }
 js-sys = "0.3.31"
 wasm-bindgen = "0.2.37"
 wasm-bindgen-futures = "0.4.4"


### PR DESCRIPTION
There is [an issue](https://github.com/Amanieu/parking_lot/issues/269) with `parking_lot >= 0.8.1`, because the previously _dummy_ `Instant` has been replaced with [the one from the `instant` crate](https://docs.rs/instant/0.1.9/instant/type.Instant.html). Unfortunately, when neither the `wasm-bindgen` or `webstd` features are passed to `instant`, it [exposes an `extern "C" now` function](https://github.com/sebcrozet/instant/blob/eff71cffcc21f0b6d84a7dc3009cacb9ff16b4ea/src/wasm.rs#L128-L133), which will create problem when linking/loading modules.

This fix is trivial and should not be breaking (right?).