### PR TITLE
fix SystemTime::elapsed()

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -147,7 +147,7 @@ impl SystemTime {
     }
 
     pub fn elapsed(&self) -> Result<Duration, ()> {
-        self.duration_since(SystemTime::now())
+        SystemTime::now().duration_since(*self)
     }
 
     pub fn checked_add(&self, duration: Duration) -> Option<SystemTime> {


### PR DESCRIPTION
On wasm32 target, SystemTime::elapsed() was throwing error due to an inversion in the chronology of Instant.
`duration_since` need an earlier Instant in argument to work properly, and self should be before now (because we want elapsed time).
So the fix is:
```rust
    pub fn elapsed(&self) -> Result<Duration, ()> {
        SystemTime::now().duration_since(*self)
    }
```