### PR TITLE
Add missing methods to Instant, matching Rust 1.39

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -70,6 +70,25 @@ impl Instant {
     pub fn elapsed(&self) -> Duration {
         Instant::now() - *self
     }
+
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        match self.cmp(&earlier) {
+            Ordering::Less => None,
+            _ => Some(self.duration_since(earlier)),
+        }
+    }
+
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        Some(*self + duration)
+    }
+
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        Some(*self - duration)
+    }
 }
 
 impl Add<Duration> for Instant {


### PR DESCRIPTION
Added some missing methods, introduced by Rust 1.39:
- [x] Instant::checked_duration_since
    > Returns the amount of time elapsed from another instant to this one, or `None` if that instant is later than this one.  
- [x] Instant::saturating_duration_since
    > Returns the amount of time elapsed from another instant to this one, or zero duration if that instant is later than this one.
- [x] Instant::checked_add
    > Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as `Instant` (which means it’s inside the bounds of the underlying data structure), `None` otherwise.

    Since it is a floating number inside, this is always true.
- [x] Instant::check_sub
    > Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as `Instant` (which means it’s inside the bounds of the underlying data structure), `None` otherwise.

    Since it is a floating number inside this is always true.